### PR TITLE
WIP Add optional onSubmit

### DIFF
--- a/re/ReForm.re
+++ b/re/ReForm.re
@@ -84,7 +84,7 @@ module Create = (Config: Config) => {
              ~setSubmitting: ReasonReact.Callback.t(bool),
              ~setError: ReasonReact.Callback.t(option(string))
            ) =>
-           unit,
+           unit=ignore,
         ~onFormStateChange: state => unit=ignore,
         ~validate: values => option(string)=(_) => None,
         ~initialState: Config.state,


### PR DESCRIPTION
Using `onFormStateChange` the onSubmit hook isn't necessary.

Better than just making it fully optional, would be nice if we could make it(optional) only when onFormStateChange is used.

Thoughts?