### PR TITLE
New Feature: Focused fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Reasonably making forms sound good again (pun 100% intended)
   * [reform.handleChange](#handlechange-configfields-string--unit)
   * [reform.handleGlobalValidation](#handleglobalvalidation-optionstring--unit)
   * [reform.resetFormState](#resetformstate-unit--unit)
-  * [reform.setFocusedField](#setfocusedfield-configfields-unit)
-  * [reform.focusedField](#focusedField-configfields)
+  * [reform.setFocusedField](#setfocusedfield-configfields--unit)
+  * [reform.focusedField](#focusedfield-optionconfigfields)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -17,12 +17,14 @@ Reasonably making forms sound good again (pun 100% intended)
   * [onFormStateChange](#onformstatechange-param)
   * [Schema](#schema)
   * [Available validators](#available-validators)
-  * [reform.form](#form)
+  * [reform.form](#form-paramsstate)
   * [reform.getErrorForField](#geterrorforfield-configfields--optionsstring)
   * [reform.handleSubmit](#handlesubmit-unit--unit)
   * [reform.handleChange](#handlechange-configfields-string--unit)
   * [reform.handleGlobalValidation](#handleglobalvalidation-optionstring--unit)
-  * [reform.resetFormState](#resetFormState-unit--unit)
+  * [reform.resetFormState](#resetformstate-unit--unit)
+  * [reform.setFocusedField](#setfocusedfield-configfields-unit)
+  * [reform.focusedField](#focusedField-configfields)
 
 ## Installation
 
@@ -222,6 +224,12 @@ Handles the global error value at `reform.form.error`
 
 ### resetFormState: unit => unit
 Reset the form to the initial state
+
+### setFocusedField: Config.fields => unit
+Set the currently focused field. You could connect this to the onFocus of an input.
+
+### focusedField: option(Config.fields)
+The currently focused field. For example usable to only show the error message when the field is not focused.
 
 ## Schema
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Reasonably making forms sound good again (pun 100% intended)
   * [reform.handleGlobalValidation](#handleglobalvalidation-optionstring--unit)
   * [reform.resetFormState](#resetformstate-unit--unit)
   * [reform.setFocusedField](#setfocusedfield-configfields--unit)
+  * [reform.unsetFocusedField](#unsetfocusedfield-unit--unit)
   * [reform.focusedField](#focusedfield-optionconfigfields)
 
 ## Installation
@@ -227,6 +228,9 @@ Reset the form to the initial state
 
 ### setFocusedField: Config.fields => unit
 Set the currently focused field. You could connect this to the onFocus of an input.
+
+### unsetFocusedField: unit => unit
+Unsets the focused field. Useful for onBlur on an input.
 
 ### focusedField: option(Config.fields)
 The currently focused field. For example usable to only show the error message when the field is not focused.

--- a/re/ReForm.re
+++ b/re/ReForm.re
@@ -33,7 +33,8 @@ module Create = (Config: Config) => {
     | HandleChange((Config.fields, value))
     | HandleSubmit
     | ResetFormState
-    | HandleFocusedField(Config.fields);
+    | HandleSetFocusedField(Config.fields)
+    | HandleUnsetFocusedField;
   type values = Config.state;
   type schema = list((Config.fields, Validation.validation(values)));
   module Field = {
@@ -86,6 +87,7 @@ module Create = (Config: Config) => {
     getErrorForField: Config.fields => option(string),
     resetFormState: unit => unit,
     setFocusedField: Config.fields => unit,
+    unsetFocusedField: unit => unit,
     focusedField: option(Config.fields),
   };
   let component = ReasonReact.reducerComponent("ReForm");
@@ -206,9 +208,14 @@ module Create = (Config: Config) => {
             }
           ),
         )
-      | HandleFocusedField(focusedField) =>
+      | HandleSetFocusedField(focusedField) =>
         UpdateWithSideEffects(
           {...state, focusedField: Some(focusedField)},
+          (self => onFormStateChange(self.state)),
+        )
+      | HandleUnsetFocusedField =>
+        UpdateWithSideEffects(
+          {...state, focusedField: None},
           (self => onFormStateChange(self.state)),
         )
       },
@@ -225,7 +232,8 @@ module Create = (Config: Config) => {
           |> List.map(((_, error)) => error)
           |> safeHd
           >>= (i => i);
-      let setFocusedField = field => self.send(HandleFocusedField(field));
+      let setFocusedField = field => self.send(HandleSetFocusedField(field));
+      let unsetFocusedField = () => self.send(HandleUnsetFocusedField);
       children({
         form: self.state,
         handleChange,
@@ -234,6 +242,7 @@ module Create = (Config: Config) => {
         getErrorForField,
         resetFormState,
         setFocusedField,
+        unsetFocusedField,
         focusedField: self.state.focusedField,
       });
     },

--- a/re/ReForm.rei
+++ b/re/ReForm.rei
@@ -19,7 +19,8 @@ module Create:
       | HandleChange((Config.fields, value))
       | HandleSubmit
       | ResetFormState
-      | HandleFocusedField(Config.fields);
+      | HandleSetFocusedField(Config.fields)
+      | HandleUnsetFocusedField;
     type values = Config.state;
     type schema = list((Config.fields, Validation.validation(values)));
     module Field: {
@@ -56,6 +57,7 @@ module Create:
       getErrorForField: Config.fields => option(string),
       resetFormState: unit => unit,
       setFocusedField: Config.fields => unit,
+      unsetFocusedField: unit => unit,
       focusedField: option(Config.fields),
     };
     let component:

--- a/re/ReForm.rei
+++ b/re/ReForm.rei
@@ -18,7 +18,8 @@ module Create:
       | HandleError(option(string))
       | HandleChange((Config.fields, value))
       | HandleSubmit
-      | ResetFormState;
+      | ResetFormState
+      | HandleFocusedField(Config.fields);
     type values = Config.state;
     type schema = list((Config.fields, Validation.validation(values)));
     module Field: {
@@ -45,6 +46,7 @@ module Create:
       isSubmitting: bool,
       errors: list((Config.fields, option(string))),
       error: option(string),
+      focusedField: option(Config.fields)
     };
     type reform = {
       form: state,
@@ -53,6 +55,8 @@ module Create:
       handleSubmit: unit => unit,
       getErrorForField: Config.fields => option(string),
       resetFormState: unit => unit,
+      setFocusedField: Config.fields => unit,
+      focusedField: option(Config.fields),
     };
     let component:
       ReasonReact.componentSpec(


### PR DESCRIPTION
After some discussion in #57 I made these changes to be able to store the focused field in Reform.

I introduced setFocusedField, unsetFocusedField and focusedField, these can be used on onFocus, onBlur and while checking if you want to show the error message.

Let me know if this is something that you'd like in reform and if I should change something :)

See example below:

**My usecase, hiding the error messages until the input is not focused anymore:**
```js
(
  {
    form,
    handleChange,
    handleSubmit,
    getErrorForField,
    setFocusedField,
    focusedField,
  },
) =>
    <div className="form-group">
      <label htmlFor="email">
        (ste("Email address"))
      </label>
      <input
        id="email"
        type_="text"
        value=form.values.email
        placeholder="julie@example.com"
        onFocus=(_event => setFocusedField(`email))
        onChange=(
          event =>
            handleChange(`email, inputValue(event))
        )
      />
      (
        switch (focusedField) {
        | Some(field) when field !== `email =>
          <p>
            (
              getErrorForField(`email)
              |> Belt.Option.getWithDefault(_, "")
              |> ReasonReact.string
            )
          </p>
        | _ => ReasonReact.null
        }
      )
    </div>
    <div className="form-group">
      <label htmlFor="password">
        (ste("Password"))
      </label>
      <input
        type_="password"
        value=form.values.password
        placeholder="Enter your password"
        onFocus=(
          _event => setFocusedField(`password)
        )
        onChange=(
          event =>
            handleChange(
              `password,
              inputValue(event),
            )
        )
      />
    </div>
    <div className="error-block">
      <p>
        (
          form.error
          |> Belt.Option.getWithDefault(_, "")
          |> ReasonReact.string
        )
      </p>
    </div>
};
```