### PR TITLE
Fix illegal backslash escape in string

### DIFF
--- a/packages/bs-reform/src/ReFormNext.re
+++ b/packages/bs-reform/src/ReFormNext.re
@@ -44,7 +44,7 @@ module Make = (Config: Config) => {
         Js.Re.test(
           Config.get(values, field),
           [%bs.re
-            "/^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/"
+            "/^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/"
           ],
         )
           ? Valid : Error("Invalid email"),


### PR DESCRIPTION
Currently compiling reform is causing:

```
reform/packages/bs-reform/src/ReFormNext.re", line 47, characters 96-98:
Warning 14: illegal backslash escape in string.
```

My PR wil make this error go away 