### PR TITLE
Feat/validate function

### DIFF
--- a/packages/bs-reform/src/ReForm.re
+++ b/packages/bs-reform/src/ReForm.re
@@ -63,6 +63,7 @@ module Make = (Config: Config) => {
       'a.
       (Config.field('a), 'a, ~shouldValidate: bool=?, unit) => unit,
 
+    validateField: field => unit,
     validateForm: unit => unit,
   };
 
@@ -303,6 +304,7 @@ module Make = (Config: Config) => {
         send(FieldArrayRemoveBy(field, predicate)),
       arrayRemoveByIndex: (field, index) =>
         send(FieldArrayRemove(field, index)),
+      validateField: field => send(ValidateField(field)),
       validateForm: () => send(ValidateForm(false)),
     };
 


### PR DESCRIPTION
This PR adds two new functions to the ReForm API: `validateForm` and `validateField`, in case the user wants to manually trigger form valitations.