### PR TITLE
feat(nested-errors,custom-errors): add nested errors for field array

### DIFF
--- a/packages/bs-reform/src/ReForm.re
+++ b/packages/bs-reform/src/ReForm.re
@@ -13,11 +13,6 @@ type fieldState =
   | NestedErrors(array(ReSchema.childFieldError))
   | Error(string);
 
-type fieldError =
-  | Error(string)
-  | Errors(array(ReSchema.childFieldError))
-  | Ok;
-
 type formState =
   | Dirty
   | Submitting
@@ -60,9 +55,9 @@ module Make = (Config: Config) => {
   type api = {
     state,
     getFieldState: field => fieldState,
-    getFieldErrorState: field => fieldError,
+    getFieldErrorState: field => fieldState,
     getFieldError: field => option(string),
-    getNestedFieldError: (field, int, string) => option(string),
+    getNestedFieldError: (field, int) => option(string),
     handleChange: 'a. (Config.field('a), 'a) => unit,
     arrayPush: 'a. (Config.field(array('a)), 'a) => unit,
     arrayUpdateByIndex:
@@ -91,7 +86,7 @@ module Make = (Config: Config) => {
 
   type fieldInterface('value) = {
     handleChange: 'value => unit,
-    error: fieldError,
+    error: fieldState,
     state: fieldState,
     validate: unit => unit,
     value: 'value,
@@ -468,15 +463,7 @@ module Make = (Config: Config) => {
         });
     };
 
-    let getFieldErrorState = field =>
-      getFieldState(field)
-      |> (
-        fun
-        | Error(error) => Error(error)
-        | NestedErrors(errors) => Errors(errors)
-        | Pristine
-        | Valid => Ok
-      );
+    let getFieldErrorState = field => getFieldState(field);
 
     let getNestedFieldError = (field, index, name) =>
       getFieldState(field)

--- a/packages/bs-reform/src/ReForm.re
+++ b/packages/bs-reform/src/ReForm.re
@@ -465,17 +465,12 @@ module Make = (Config: Config) => {
 
     let getFieldErrorState = field => getFieldState(field);
 
-    let getNestedFieldError = (field, index, name) =>
+    let getNestedFieldError = (field, index) =>
       getFieldState(field)
       |> (
         fun
         | NestedErrors(errors) => {
-            switch (
-              errors
-              |> Js.Array.find(error =>
-                   error.index == index && error.name == name
-                 )
-            ) {
+            switch (errors->Belt.Array.get(index)) {
             | None => None
             | Some(error) => Some(error.error)
             };

--- a/packages/reschema/src/ReSchema.re
+++ b/packages/reschema/src/ReSchema.re
@@ -5,13 +5,20 @@ module type Lenses = {
   let get: (state, field('a)) => 'a;
 };
 
+type childFieldError = {
+  error: string,
+  index: int,
+  name: string,
+};
+
 type fieldState =
   | Valid
+  | NestedErrors(array(childFieldError))
   | Error(string);
 
 type recordValidationState('a) =
   | Valid
-  | Errors(array(('a, string)));
+  | Errors(array(('a, fieldState)));
 
 module Make = (Lenses: Lenses) => {
   type field =
@@ -19,16 +26,16 @@ module Make = (Lenses: Lenses) => {
 
   module Validation = {
     type t =
-      | Email(Lenses.field(string)): t
+      | Email(Lenses.field(string), option(string)): t
       | NoValidation(Lenses.field('a)): t
-      | StringNonEmpty(Lenses.field(string)): t
-      | StringRegExp(Lenses.field(string), string): t
-      | StringMin(Lenses.field(string), int): t
-      | StringMax(Lenses.field(string), int): t
-      | IntMin(Lenses.field(int), int): t
-      | IntMax(Lenses.field(int), int): t
-      | FloatMin(Lenses.field(float), float): t
-      | FloatMax(Lenses.field(float), float): t
+      | StringNonEmpty(Lenses.field(string), option(string)): t
+      | StringRegExp(Lenses.field(string), string, option(string)): t
+      | StringMin(Lenses.field(string), int, option(string)): t
+      | StringMax(Lenses.field(string), int, option(string)): t
+      | IntMin(Lenses.field(int), int, option(string)): t
+      | IntMax(Lenses.field(int), int, option(string)): t
+      | FloatMin(Lenses.field(float), float, option(string)): t
+      | FloatMax(Lenses.field(float), float, option(string)): t
       | Custom(Lenses.field('a), Lenses.state => fieldState): t;
     type schema =
       | Schema(array(t)): schema;
@@ -41,66 +48,115 @@ module Make = (Lenses: Lenses) => {
   let validateField =
       (~validator, ~values, ~i18n: ReSchemaI18n.t): (field, fieldState) =>
     switch (validator) {
-    | Validation.IntMin(field, min) =>
+    | Validation.IntMin(field, min, customErrorMessage) =>
       let value = Lenses.get(values, field);
       (
         Field(field),
-        value >= min ? Valid : Error(i18n.intMin(~value, ~min)),
+        value >= min
+          ? Valid
+          : Error(
+              customErrorMessage->Belt.Option.getWithDefault(
+                i18n.intMin(~value, ~min),
+              ),
+            ),
       );
-    | Validation.IntMax(field, max) =>
+    | Validation.IntMax(field, max, customErrorMessage) =>
       let value = Lenses.get(values, field);
 
       (
         Field(field),
-        value <= max ? Valid : Error(i18n.intMax(~value, ~max)),
+        value <= max
+          ? Valid
+          : Error(
+              customErrorMessage->Belt.Option.getWithDefault(
+                i18n.intMax(~value, ~max),
+              ),
+            ),
       );
-    | Validation.FloatMin(field, min) =>
+    | Validation.FloatMin(field, min, customErrorMessage) =>
       let value = Lenses.get(values, field);
       (
         Field(field),
-        value >= min ? Valid : Error(i18n.floatMin(~value, ~min)),
+        value >= min
+          ? Valid
+          : Error(
+              customErrorMessage->Belt.Option.getWithDefault(
+                i18n.floatMin(~value, ~min),
+              ),
+            ),
       );
-    | Validation.FloatMax(field, max) =>
+    | Validation.FloatMax(field, max, customErrorMessage) =>
       let value = Lenses.get(values, field);
       (
         Field(field),
         Lenses.get(values, field) <= max
-          ? Valid : Error(i18n.floatMax(~value, ~max)),
+          ? Valid
+          : Error(
+              customErrorMessage->Belt.Option.getWithDefault(
+                i18n.floatMax(~value, ~max),
+              ),
+            ),
       );
-    | Validation.Email(field) =>
+    | Validation.Email(field, customErrorMessage) =>
       let value = Lenses.get(values, field);
       (
         Field(field),
         Js.Re.test_(RegExps.email, value)
-          ? Valid : Error(i18n.email(~value)),
+          ? Valid
+          : Error(
+              customErrorMessage->Belt.Option.getWithDefault(
+                i18n.email(~value),
+              ),
+            ),
       );
     | Validation.NoValidation(field) => (Field(field), Valid)
-    | Validation.StringNonEmpty(field) =>
+    | Validation.StringNonEmpty(field, customErrorMessage) =>
       let value = Lenses.get(values, field);
       (
         Field(field),
-        value === "" ? Error(i18n.stringNonEmpty(~value)) : Valid,
+        value === ""
+          ? Error(
+              customErrorMessage->Belt.Option.getWithDefault(
+                i18n.stringNonEmpty(~value),
+              ),
+            )
+          : Valid,
       );
-    | Validation.StringRegExp(field, regexp) =>
+    | Validation.StringRegExp(field, regexp, customErrorMessage) =>
       let value = Lenses.get(values, field);
       (
         Field(field),
         Js.Re.test_(Js.Re.fromString(regexp), value)
-          ? Valid : Error(i18n.stringRegExp(~value, ~pattern=regexp)),
+          ? Valid
+          : Error(
+              customErrorMessage->Belt.Option.getWithDefault(
+                i18n.stringRegExp(~value, ~pattern=regexp),
+              ),
+            ),
       );
-    | Validation.StringMin(field, min) =>
+    | Validation.StringMin(field, min, customErrorMessage) =>
       let value = Lenses.get(values, field);
       (
         Field(field),
         Js.String.length(value) >= min
-          ? Valid : Error(i18n.stringMin(~value, ~min)),
+          ? Valid
+          : Error(
+              customErrorMessage->Belt.Option.getWithDefault(
+                i18n.stringMin(~value, ~min),
+              ),
+            ),
       );
-    | Validation.StringMax(field, max) =>
+    | Validation.StringMax(field, max, customErrorMessage) =>
       let value = Lenses.get(values, field);
       (
         Field(field),
         Js.String.length(value) <= max
-          ? Valid : Error(i18n.stringMax(~value, ~max)),
+          ? Valid
+          : Error(
+              customErrorMessage->Belt.Option.getWithDefault(
+                i18n.stringMax(~value, ~max),
+              ),
+            ),
       );
     | Validation.Custom(field, predicate) => (
         Field(field),
@@ -112,16 +168,16 @@ module Make = (Lenses: Lenses) => {
     validators
     ->Belt.Array.keep(validator =>
         switch (validator) {
-        | Validation.IntMin(field, _) => Field(field) == fieldName
-        | Validation.IntMax(field, _) => Field(field) == fieldName
-        | Validation.FloatMin(field, _) => Field(field) == fieldName
-        | Validation.FloatMax(field, _) => Field(field) == fieldName
-        | Validation.Email(field) => Field(field) == fieldName
+        | Validation.IntMin(field, _, _) => Field(field) == fieldName
+        | Validation.IntMax(field, _, _) => Field(field) == fieldName
+        | Validation.FloatMin(field, _, _) => Field(field) == fieldName
+        | Validation.FloatMax(field, _, _) => Field(field) == fieldName
+        | Validation.Email(field, _) => Field(field) == fieldName
         | Validation.NoValidation(field) => Field(field) == fieldName
-        | Validation.StringNonEmpty(field) => Field(field) == fieldName
-        | Validation.StringRegExp(field, _) => Field(field) == fieldName
-        | Validation.StringMin(field, _) => Field(field) == fieldName
-        | Validation.StringMax(field, _) => Field(field) == fieldName
+        | Validation.StringNonEmpty(field, _) => Field(field) == fieldName
+        | Validation.StringRegExp(field, _, _) => Field(field) == fieldName
+        | Validation.StringMin(field, _, _) => Field(field) == fieldName
+        | Validation.StringMax(field, _, _) => Field(field) == fieldName
         | Validation.Custom(field, _) => Field(field) == fieldName
         }
       )
@@ -163,15 +219,7 @@ module Make = (Lenses: Lenses) => {
     let errors =
       validationList
       ->Belt.Array.keep(((_field, fieldState)) => fieldState !== Valid)
-      ->Belt.Array.map(((field, fieldState)) =>
-          switch (fieldState) {
-          | Valid => (field, None)
-          | Error(message) => (field, Some(message))
-          }
-        )
-      ->Belt.Array.map(((field, message)) =>
-          (field, message->Belt.Option.getWithDefault(""))
-        );
+      ->Belt.Array.map(((field, fieldState)) => (field, fieldState));
 
     Belt.Array.length(errors) > 0 ? Errors(errors) : Valid;
   };


### PR DESCRIPTION
Add the ability for fields within a field array to have their own validation and errors.

Add the option to add a custom error message for each validation schema.