### PR TITLE
Receive updated fieldsState in onSubmitFail

### DIFF
--- a/packages/bs-reform/src/ReForm.re
+++ b/packages/bs-reform/src/ReForm.re
@@ -258,7 +258,10 @@ module Make = (Config: Config) => {
                 submit
                   ? onSubmitFail({
                       send: self.send,
-                      state: self.state,
+                      state: {
+                        ...self.state,
+                        fieldsState: newFieldsState,
+                      },
                       raiseSubmitFailed: error =>
                         self.send(RaiseSubmitFailed(error)),
                     })


### PR DESCRIPTION
`state.fieldsState` received in `onSubmitFail` isn't updated with the new `newFieldsState` created in the `ValidateForm` action.

It's especially visible at first try: submit a form without touching any fields result to an `onSubmitFail` without any error in `state.fieldsState`