### PR TITLE
fix: update lenses-ppx dependency

### DIFF
--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "autoprefixer": "^9.8.5",
     "css-loader": "^4.1.0",
-    "lenses-ppx": "^5.1.0",
+    "lenses-ppx": "^6.1.3",
     "style-loader": "^1.2.1",
     "webpack": "^4.39.3",
     "webpack-cli": "^3.3.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6019,10 +6019,10 @@ left-pad@^1.3.0:
   resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
   integrity sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==
 
-lenses-ppx@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/lenses-ppx/-/lenses-ppx-5.1.0.tgz#74882abc99f09fdb03daf33fd4ee79272424be7a"
-  integrity sha512-q+5yxYvvF8czdfRkBXYoqBeDUJkLQz6VUkPiFmUIdyMm6HWPvKnLJYPF1HRHeTp+KtkblBY5sHvmOWBfEpUGnw==
+lenses-ppx@^6.1.3:
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/lenses-ppx/-/lenses-ppx-6.1.3.tgz#cfb0a1c50aa65ac0784a38f562bbfc9995774fd0"
+  integrity sha512-Dk5VuMIytNSgkO5VXrnt9NdTlOMXNS8XTyXfi7gBgqo437F3/qCnDvNaHIWaXDmzoILE+Nxgi+xxcXoXb4SEpQ==
 
 lerna@^3.14.1:
   version "3.22.1"


### PR DESCRIPTION
This updates the lenses ppx dependency for the demo package.

Fixes the `'with' clause is useless` message whenever state lenses have only one field.

Related to #195 