### PR TITLE
fix(reschema): test expectation is wrong

### DIFF
--- a/packages/reschema/__tests__/Schema_Test.res
+++ b/packages/reschema/__tests__/Schema_Test.res
@@ -61,7 +61,7 @@ describe("Schema", (. ()) => {
     | None => ()
     | Some((field, error)) => {
         expect(field)->toStrictEqual(Field(Email))->ignore
-        expect(error)->toStrictEqual(Error("Invalid email."))->ignore
+        expect(error)->toStrictEqual(Error("Invalid email"))->ignore
       }
     }
   })


### PR DESCRIPTION
Expected test result did not match the error message that was set up earlier in the test. Corrected this by removing the full stop from the expect statement.